### PR TITLE
Update GitHub Actions workflow to use 'uv sync' instead of 'uv pip in…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build release distributions
         run: |
-          uv pip install build
+          uv sync
           uv build
 
       - name: Upload distributions


### PR DESCRIPTION
…stall build' for building release distributions.